### PR TITLE
Use setuptools to generate console scripts.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include scripts/django
 include README.rst
 include LICENSE

--- a/django_shortcuts.py
+++ b/django_shortcuts.py
@@ -68,4 +68,10 @@ def run(command=None, *arguments):
         'arguments': ' '.join(arguments)
     }, shell=True)
 
-run(*sys.argv[1:])
+
+def main():
+    """Entry-point function."""
+    run(*sys.argv[1:])
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+from setuptools import setup
 
 readme = open('README.rst').read()
 
@@ -10,7 +13,7 @@ setup(
     author = "Johannes Gorset",
     author_email = "jgorset@gmail.com",
     url = "http://github.com/jgorset/django-shortcuts",
-    scripts = ['scripts/django'],
+    py_modules = ['django_shortcuts'],
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -19,5 +22,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7'
-    ]
+    ],
+    entry_points={
+        'console_scripts': [
+            'django = django_shortcuts:main',
+        ]
+    },
 )


### PR DESCRIPTION
First of all this is a great project. Its actually one of these projects that should be created years ago.

Secondly, I would love to use it on any platform (including Windows) out of the box, so I converted it to a package and added entry points declaration to the `setup.py` file to automatically generate console scripts[1].

The setup process now requires setuptools instead of plain distutils, but it makes it cross-platform (tested on Windows and Ubuntu with virtualenv).

[1] http://packages.python.org/distribute/setuptools.html#automatic-script-creation
