### PR TITLE
Friendly error message when trying to run without a command

### DIFF
--- a/django_shortcuts.py
+++ b/django_shortcuts.py
@@ -12,23 +12,23 @@ ALIASES = {
     'sp' : 'startproject',
     'sa' : 'startapp',
     't'  : 'test',
-    
+
     # Shell
     'd'  : 'dbshell',
     's'  : 'shell',
-    
+
     # Auth
     'csu': 'createsuperuser',
     'cpw': 'changepassword',
-    
+
     # South
     'm'  : 'migrate',
     'sm' : 'schemamigration',
-    
+
     # Haystack
     'ix' : 'update_index',
     'rix': 'rebuild_index',
-    
+
     # Django Extensions
     'sk' : 'generate_secret_key',
     'rdb': 'reset_db',
@@ -50,6 +50,9 @@ def run(command=None, *arguments):
 
     if command == 'startproject' or ALIASES[command] == 'startproject':
         return call('django-admin.py startproject %s' % ' '.join(arguments), shell=True)
+    elif command is None:
+        sys.exit('django-shortcuts: No argument was supplied, please specify one.')
+
 
     if command and command in ALIASES:
         command = ALIASES[command]


### PR DESCRIPTION
Running:

``` bash
$ django
```

In a folder with no Django project, spits out this traceback:

``` bash
Traceback (most recent call last):
  File "/Users/Tomas/.virtualenvs/todo-app/bin/django", line 9, in <module>
    load_entry_point('django-shortcuts==1.4', 'console_scripts', 'django')()
  File "/Users/Tomas/.virtualenvs/todo-app/lib/python2.7/site-packages/django_shortcuts.py", line 75, in main
    run(*sys.argv[1:])
  File "/Users/Tomas/.virtualenvs/todo-app/lib/python2.7/site-packages/django_shortcuts.py", line 51, in run
    if command == 'startproject' or ALIASES[command] == 'startproject':
KeyError: None
```

So it's just missing a friendly error message.
